### PR TITLE
6 exception raised if depth level is not set

### DIFF
--- a/oc_delivery_apps/checksums/controllers.py
+++ b/oc_delivery_apps/checksums/controllers.py
@@ -701,7 +701,7 @@ class CheckSumsController(object):
         :return int: current inclusion level (may be None)
         """
         file_r.refresh_from_db()
-        return file_r.depth_level
+        return file_r.depth_level or 0
 
     def _update_current_inclusion_depth(self, file_r, inclusion_level):
         """
@@ -711,7 +711,7 @@ class CheckSumsController(object):
         :return: modified file_r with new inclusion level set
         """
         file_r.refresh_from_db()
-        file_r.depth_level = max(file_r.depth_level, inclusion_level)
+        file_r.depth_level = max(file_r.depth_level or 0, inclusion_level or 0)
         file_r.save()
         return file_r
 

--- a/oc_delivery_apps/checksums/controllers.py
+++ b/oc_delivery_apps/checksums/controllers.py
@@ -229,7 +229,6 @@ class CheckSumsController(object):
         # get rid of trash in the arguments
         location = location.strip()
         loc_type = loc_type.strip().upper()
-        ci_type = ci_type.strip().upper()
         mime_type = mime_type.strip()
         checksum = checksum.strip()
         cs_type = cs_type.strip().upper()
@@ -238,14 +237,13 @@ class CheckSumsController(object):
         if not self._is_strict_cs_prov(cs_prov):
             return False
 
+        if not ci_type:
+            ci_type = self.ci_type_by_path(location, loc_type)
+
         # otherwise store all. IS_DELETED will be False by Model.
         _ci_type = models.CiTypes.objects.filter(code=ci_type).last()
         _loc = None
         _cs = None
-
-        if not _ci_type:
-            # do not using 'get' since it will raise unnecessary exception in case of failure
-            _ci_type = models.CiTypes.objects.filter(code="FILE").last()
 
         try:
             with transaction.atomic():
@@ -378,7 +376,7 @@ class CheckSumsController(object):
             if re.match(_regexp_s, path):
                 return _regexp.ci_type.code
 
-        return None
+        return 'FILE'
 
     def ci_type_by_gav(self, gav):
         """

--- a/oc_delivery_apps/dlcontents/controllers.py
+++ b/oc_delivery_apps/dlcontents/controllers.py
@@ -702,7 +702,7 @@ class CheckSumsController(object):
         :return int: current inclusion level (may be None)
         """
         file_r.refresh_from_db()
-        return file_r.depth_level
+        return file_r.depth_level or 0
 
     def _update_current_inclusion_depth(self, file_r, inclusion_level):
         """
@@ -712,7 +712,7 @@ class CheckSumsController(object):
         :return: modified file_r with new inclusion level set
         """
         file_r.refresh_from_db()
-        file_r.depth_level = max(file_r.depth_level, inclusion_level)
+        file_r.depth_level = max(file_r.depth_level or 0, inclusion_level or 0)
         file_r.save()
         return file_r
 

--- a/oc_delivery_apps/dlcontents/controllers.py
+++ b/oc_delivery_apps/dlcontents/controllers.py
@@ -230,7 +230,6 @@ class CheckSumsController(object):
         # get rid of trash in the arguments
         location = location.strip()
         loc_type = loc_type.strip().upper()
-        ci_type = ci_type.strip().upper()
         mime_type = mime_type.strip()
         checksum = checksum.strip()
         cs_type = cs_type.strip().upper()
@@ -239,14 +238,13 @@ class CheckSumsController(object):
         if not self._is_strict_cs_prov(cs_prov):
             return False
 
+        if not ci_type:
+            ci_type = self.ci_type_by_path(location, loc_type)
+
         # otherwise store all. IS_DELETED will be False by Model.
         _ci_type = models.CiTypes.objects.filter(code=ci_type).last()
         _loc = None
         _cs = None
-
-        if not _ci_type:
-            # do not using 'get' since it will raise unnecessary exception in case of failure
-            _ci_type = models.CiTypes.objects.filter(code="FILE").last()
 
         try:
             with transaction.atomic():
@@ -379,7 +377,7 @@ class CheckSumsController(object):
             if re.match(_regexp_s, path):
                 return _regexp.ci_type.code
 
-        return None
+        return 'FILE'
 
     def ci_type_by_gav(self, gav):
         """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import glob
 import os
 
-__version = "11.2.8"
+__version = "11.2.9"
 
 spec = {
     "name": "oc-delivery-apps",


### PR DESCRIPTION
- added zero substitution in case no `depth_level` is specified in `FILE` record directly
- re-factored default `ci_type` detection (`FILE`)
- Version increased