### PR TITLE
10 fix file name too long exception while unpacking archives in checksumsdlcontents applications

### DIFF
--- a/oc_delivery_apps/checksums/archive_object.py
+++ b/oc_delivery_apps/checksums/archive_object.py
@@ -101,7 +101,9 @@ class ArchiveObject(object):
         :return NamedTemporaryFile:
         """
 
-        _rs = tempfile.NamedTemporaryFile(suffix=posixpath.basename(pth_e))
+        _sfx = posixpath.basename(pth_e)
+        _sfx = list(posixpath.splitext(pth_e)).pop()
+        _rs = tempfile.NamedTemporaryFile(suffix=_sfx)
 
         if self._mode == 'TAR':
             # unfortunately 'shutil.copyfileobj' does not work properly here

--- a/oc_delivery_apps/checksums/archive_object.py
+++ b/oc_delivery_apps/checksums/archive_object.py
@@ -101,9 +101,9 @@ class ArchiveObject(object):
         :return NamedTemporaryFile:
         """
 
-        _sfx = posixpath.basename(pth_e)
-        _sfx = list(posixpath.splitext(pth_e)).pop()
-        _rs = tempfile.NamedTemporaryFile(suffix=_sfx)
+        # make suffix as extension only - needed for 'wrap' to work correctly
+        # limit it to five characters - usually it is enough for real extensions
+        _rs = tempfile.NamedTemporaryFile(suffix=list(posixpath.splitext(pth_e)).pop()[0:5])
 
         if self._mode == 'TAR':
             # unfortunately 'shutil.copyfileobj' does not work properly here

--- a/oc_delivery_apps/dlcontents/archive_object.py
+++ b/oc_delivery_apps/dlcontents/archive_object.py
@@ -101,7 +101,9 @@ class ArchiveObject(object):
         :return NamedTemporaryFile:
         """
 
-        _rs = tempfile.NamedTemporaryFile(suffix=posixpath.basename(pth_e))
+        _sfx = posixpath.basename(pth_e)
+        _sfx = list(posixpath.splitext(pth_e)).pop()
+        _rs = tempfile.NamedTemporaryFile(suffix=_sfx)
 
         if self._mode == 'TAR':
             # unfortunately 'shutil.copyfileobj' does not work properly here

--- a/oc_delivery_apps/dlcontents/archive_object.py
+++ b/oc_delivery_apps/dlcontents/archive_object.py
@@ -101,9 +101,9 @@ class ArchiveObject(object):
         :return NamedTemporaryFile:
         """
 
-        _sfx = posixpath.basename(pth_e)
-        _sfx = list(posixpath.splitext(pth_e)).pop()
-        _rs = tempfile.NamedTemporaryFile(suffix=_sfx)
+        # make suffix as extension only - needed for 'wrap' to work correctly
+        # limit it to five characters - usually it is enough for real extensions
+        _rs = tempfile.NamedTemporaryFile(suffix=list(posixpath.splitext(pth_e)).pop()[0:5])
 
         if self._mode == 'TAR':
             # unfortunately 'shutil.copyfileobj' does not work properly here

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import glob
 import os
 
-__version = "11.2.9"
+__version = "11.2.10"
 
 spec = {
     "name": "oc-delivery-apps",


### PR DESCRIPTION
Tempfile suffix for unpacking archive shortened to extension only, limited for 5 chars (including dot) which is usually enough.
Extension is necessary for `wrap` to work since it appends it iteslf by its own if not given.