### PR TITLE
12 archive registration debug ouptput and sql detection

### DIFF
--- a/oc_delivery_apps/checksums/controllers.py
+++ b/oc_delivery_apps/checksums/controllers.py
@@ -809,7 +809,7 @@ class CheckSumsController(object):
         file_o.seek(0, 0)
         _inclusion_level_calc_src = inclusion_level_calc
 
-        if not self._is_sql_extension(loc_path, loc_type) and not _normalizer.is_sql(file_o.read(self.__sql_limit)):
+        if not self._is_sql_extension(loc_path, loc_type) or not _normalizer.is_sql(file_o.read(self.__sql_limit)):
             # calculate file checksum
             _md5sum = self.md5(file_o)
             # register MD5 sum as "Regular" for non-sql files

--- a/oc_delivery_apps/checksums/controllers.py
+++ b/oc_delivery_apps/checksums/controllers.py
@@ -847,7 +847,7 @@ class CheckSumsController(object):
             # Try to make it 'FILE' and raise an exception if not found
             _ci_type_r = models.CiTypes.objects.filter(code='FILE').last()
         
-        if not _ci_type:
+        if not _ci_type_r:
             raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
         else:
             logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)

--- a/oc_delivery_apps/checksums/controllers.py
+++ b/oc_delivery_apps/checksums/controllers.py
@@ -619,7 +619,7 @@ class CheckSumsController(object):
                 _fl_m_r = self._reg_all_sql_cs_provs(_fl_m_r, _cs_d)
 
         except IntegrityError as _e:
-            logging.exception(_e)
+            logging.debug(repr(_e), exc_info=True)
             _fl_m_r = self.get_file_by_checksums_dict(_cs_d)
 
             if _fl_m_r is None:

--- a/oc_delivery_apps/checksums/controllers.py
+++ b/oc_delivery_apps/checksums/controllers.py
@@ -244,8 +244,14 @@ class CheckSumsController(object):
         _ci_type = models.CiTypes.objects.filter(code=ci_type).last()
 
         if not _ci_type:
-            # may be wrong type specified by caller, raise an exception
-            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+            # may be wrong type specified by caller.
+            # Try to make it 'FILE' and raise an exception if not found
+            _ci_type = models.CiTypes.objects.filter(code='FILE').last()
+        
+        if not _ci_type:
+            raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
+        else:
+            logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)
 
         _loc = None
         _cs = None
@@ -615,8 +621,14 @@ class CheckSumsController(object):
         _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
 
         if not _ci_type_r:
-            # may be wrong type specified by caller, raise an exception
-            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+            # may be wrong type specified by caller.
+            # Try to make it 'FILE' and raise an exception if not found
+            _ci_type_r = models.CiTypes.objects.filter(code='FILE').last()
+        
+        if not _ci_type_r:
+            raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
+        else:
+            logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)
 
         file_o.seek(0, os.SEEK_SET)
         _cs_d = self.get_all_sql_checksums(file_o)
@@ -641,7 +653,7 @@ class CheckSumsController(object):
         # check arguments is not needed since they are checked in sub-methods
         # one exception: location and location type have to be set in pair
         if loc_path and not loc_type:
-            raise ValueError("loc_path is specified but loc_type is missing")
+            raise ValueError("'loc_path' is specified but 'loc_type' is missing")
 
         if loc_path: 
             self.add_location(_fl_m_r, loc_path, loc_type, loc_revision)
@@ -823,7 +835,7 @@ class CheckSumsController(object):
         # check arguments is not needed since they are checked in sub-methods
         # one exception: location and location type have to be set in pair
         if loc_path and not loc_type:
-            raise ValueError("loc_path is specified but loc_type missing")
+            raise ValueError("'loc_path' is specified but 'loc_type' missing")
 
         if not ci_type:
             ci_type = self.ci_type_by_path(loc_path, loc_type)
@@ -831,8 +843,14 @@ class CheckSumsController(object):
         _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
 
         if not _ci_type_r:
-            # may be wrong type specified by caller, raise an exception
-            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+            # may be wrong type specified by caller.
+            # Try to make it 'FILE' and raise an exception if not found
+            _ci_type_r = models.CiTypes.objects.filter(code='FILE').last()
+        
+        if not _ci_type:
+            raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
+        else:
+            logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)
 
         _fl_r = None
 
@@ -1035,7 +1053,7 @@ class CheckSumsController(object):
         """
 
         if step not in list(self.__cs_providers.keys()):
-            raise ValueError("%s not found in providers list" % step)
+            raise ValueError("[%s]: not found in providers list" % step)
 
         _result = dict()
 

--- a/oc_delivery_apps/checksums/controllers.py
+++ b/oc_delivery_apps/checksums/controllers.py
@@ -242,6 +242,11 @@ class CheckSumsController(object):
 
         # otherwise store all. IS_DELETED will be False by Model.
         _ci_type = models.CiTypes.objects.filter(code=ci_type).last()
+
+        if not _ci_type:
+            # may be wrong type specified by caller, raise an exception
+            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+
         _loc = None
         _cs = None
 
@@ -609,6 +614,10 @@ class CheckSumsController(object):
 
         _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
 
+        if not _ci_type_r:
+            # may be wrong type specified by caller, raise an exception
+            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+
         file_o.seek(0, os.SEEK_SET)
         _cs_d = self.get_all_sql_checksums(file_o)
         _fl_m_r = None
@@ -820,6 +829,11 @@ class CheckSumsController(object):
             ci_type = self.ci_type_by_path(loc_path, loc_type)
 
         _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
+
+        if not _ci_type_r:
+            # may be wrong type specified by caller, raise an exception
+            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+
         _fl_r = None
 
         try:
@@ -1313,6 +1327,9 @@ class CheckSumsController(object):
             raise ValueError("Version is mandatory")
 
         _citype = models.CiTypes.objects.get(code=ci_type)
+
+        if not _citype:
+            raise ValueError("No documentation CI_TYPE found: [%s]" % ci_type)
 
         if _citype.doc_artifactid:
             return _citype.get_doc_gav(version)

--- a/oc_delivery_apps/checksums/tests/test_controllers.py
+++ b/oc_delivery_apps/checksums/tests/test_controllers.py
@@ -375,7 +375,8 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
             _cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0)
 
         # now add the type - error sould disappear
-        models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="Y", is_deliverable=True).save()
+        _citype = models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="N", is_deliverable=False)
+        _citype.save()
         self.assertTrue(_cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0))
         self.assertEqual(models.Files.objects.count(), 1)
         self.assertEqual(models.Locations.objects.count(), 2)
@@ -389,8 +390,6 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
 
         # store file with another checksum but for existing location
         # file should be added and location overwritten
-        _citype = models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="N", is_deliverable=False)
-        _citype.save()
         _cs_t = "1"*32
         self.assertTrue(_cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0))
         self.assertEqual(models.Files.objects.count(), 2)

--- a/oc_delivery_apps/checksums/tests/test_controllers.py
+++ b/oc_delivery_apps/checksums/tests/test_controllers.py
@@ -375,7 +375,7 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
             _cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0)
 
         # now add the type - error sould disappear
-        _citype = models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="Y", is_deliverable=True)
+        models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="Y", is_deliverable=True).save()
         self.assertTrue(_cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0))
         self.assertEqual(models.Files.objects.count(), 1)
         self.assertEqual(models.Locations.objects.count(), 2)

--- a/oc_delivery_apps/checksums/tests/test_controllers.py
+++ b/oc_delivery_apps/checksums/tests/test_controllers.py
@@ -1282,7 +1282,7 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
 
         with unittest.mock.patch("oc_delivery_apps.checksums.controllers.wrapper.PLSQLWrapper", return_value=MockWrapper()) as _x:
             _csc = CheckSumsController()
-            _csc.register_file_obj(_sql_f, "CODE_TYPE_1", "pl.sql.procedure:testproc:1.1.1", "NXS")
+            _csc.register_file_obj(_sql_f, "CODE_TYPE_1", "pl.sql.procedure:testproc:1.1.1:sql", "NXS")
             _x.assert_called()
 
         self.assertEqual(models.Files.objects.count(), 2)

--- a/oc_delivery_apps/checksums/tests/test_controllers.py
+++ b/oc_delivery_apps/checksums/tests/test_controllers.py
@@ -931,11 +931,15 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
 
         with self.assertRaises(ValueError):
             # ci_type is not detected - location missing
+            # "FILE" type is missing too
             _csc.register_file_md5(_cs2_t, None, "text/hypertrophed", None, "NXS")
 
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValueError):
             # ci_type is not detected - no regular expression
             _csc.register_file_md5(_cs2_t, None, "text/hypertrophed", "loc:path:3", "NXS")
+
+        # add 'FILE' type to get rid of ValueError in further asserts
+        models.CiTypes(code="FILE", name="A File", is_standard="N", is_deliverable=True).save()
 
         _fr_t2 = _csc.register_file_md5(_cs2_t, None, "text/hypertrophed", "loc:path:2:ext", "NXS")
         self.assertNotEqual(_fr_t2, _fr_t1)
@@ -1087,7 +1091,7 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
         self.assertEqual(_fl_r, models.Files.objects.last())
 
         # No ci_type_sub given
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValueError):
             _csc._register_includes(_arc_tgz_tmp, None, None, 1, False, 0)
 
         # No file record for an archive: try to find out file by file object

--- a/oc_delivery_apps/checksums/tests/test_controllers.py
+++ b/oc_delivery_apps/checksums/tests/test_controllers.py
@@ -369,6 +369,13 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
         # NOTE: non-existent CI_TYPE is specified, this is NOT A BUG
         _loctype = models.LocTypes(code="SVN", name="SubVersion")
         _loctype.save()
+
+        # first it should raise an erorr - we do not have 'CODE_TYPE_2" here and "FILE" is missing also
+        with self.assertRaises(ValueError):
+            _cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0)
+
+        # now add the type - error sould disappear
+        _citype = models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="Y", is_deliverable=True)
         self.assertTrue(_cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0))
         self.assertEqual(models.Files.objects.count(), 1)
         self.assertEqual(models.Locations.objects.count(), 2)

--- a/oc_delivery_apps/dlcontents/controllers.py
+++ b/oc_delivery_apps/dlcontents/controllers.py
@@ -848,7 +848,7 @@ class CheckSumsController(object):
             # Try to make it 'FILE' and raise an exception if not found
             _ci_type_r = models.CiTypes.objects.filter(code='FILE').last()
         
-        if not _ci_type:
+        if not _ci_type_r:
             raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
         else:
             logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)

--- a/oc_delivery_apps/dlcontents/controllers.py
+++ b/oc_delivery_apps/dlcontents/controllers.py
@@ -620,7 +620,7 @@ class CheckSumsController(object):
                 _fl_m_r = self._reg_all_sql_cs_provs(_fl_m_r, _cs_d)
 
         except IntegrityError as _e:
-            logging.exception(_e)
+            logging.debug(repr(_e), exc_info=True)
             _fl_m_r = self.get_file_by_checksums_dict(_cs_d)
 
             if _fl_m_r is None:

--- a/oc_delivery_apps/dlcontents/controllers.py
+++ b/oc_delivery_apps/dlcontents/controllers.py
@@ -245,8 +245,14 @@ class CheckSumsController(object):
         _ci_type = models.CiTypes.objects.filter(code=ci_type).last()
 
         if not _ci_type:
-            # may be wrong type specified by caller, raise an exception
-            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+            # may be wrong type specified by caller.
+            # Try to make it 'FILE' and raise an exception if not found
+            _ci_type = models.CiTypes.objects.filter(code='FILE').last()
+        
+        if not _ci_type:
+            raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
+        else:
+            logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)
 
         _loc = None
         _cs = None
@@ -616,8 +622,14 @@ class CheckSumsController(object):
         _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
 
         if not _ci_type_r:
-            # may be wrong type specified by caller, raise an exception
-            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+            # may be wrong type specified by caller.
+            # Try to make it 'FILE' and raise an exception if not found
+            _ci_type_r = models.CiTypes.objects.filter(code='FILE').last()
+        
+        if not _ci_type_r:
+            raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
+        else:
+            logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)
 
         file_o.seek(0, os.SEEK_SET)
         _cs_d = self.get_all_sql_checksums(file_o)
@@ -642,7 +654,7 @@ class CheckSumsController(object):
         # check arguments is not needed since they are checked in sub-methods
         # one exception: location and location type have to be set in pair
         if loc_path and not loc_type:
-            raise ValueError("loc_path is specified but loc_type is missing")
+            raise ValueError("'loc_path' is specified but 'loc_type' is missing")
 
         if loc_path: 
             self.add_location(_fl_m_r, loc_path, loc_type, loc_revision)
@@ -824,7 +836,7 @@ class CheckSumsController(object):
         # check arguments is not needed since they are checked in sub-methods
         # one exception: location and location type have to be set in pair
         if loc_path and not loc_type:
-            raise ValueError("loc_path is specified but loc_type missing")
+            raise ValueError("'loc_path' is specified but 'loc_type' missing")
 
         if not ci_type:
             ci_type = self.ci_type_by_path(loc_path, loc_type)
@@ -832,8 +844,14 @@ class CheckSumsController(object):
         _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
 
         if not _ci_type_r:
-            # may be wrong type specified by caller, raise an exception
-            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+            # may be wrong type specified by caller.
+            # Try to make it 'FILE' and raise an exception if not found
+            _ci_type_r = models.CiTypes.objects.filter(code='FILE').last()
+        
+        if not _ci_type:
+            raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
+        else:
+            logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)
 
         _fl_r = None
 
@@ -1036,7 +1054,7 @@ class CheckSumsController(object):
         """
 
         if step not in list(self.__cs_providers.keys()):
-            raise ValueError("%s not found in providers list" % step)
+            raise ValueError("[%s]: not found in providers list" % step)
 
         _result = dict()
 

--- a/oc_delivery_apps/dlcontents/controllers.py
+++ b/oc_delivery_apps/dlcontents/controllers.py
@@ -810,7 +810,7 @@ class CheckSumsController(object):
         file_o.seek(0, 0)
         _inclusion_level_calc_src = inclusion_level_calc
 
-        if not self._is_sql_extension(loc_path, loc_type) and not _normalizer.is_sql(file_o.read(self.__sql_limit)):
+        if not self._is_sql_extension(loc_path, loc_type) or not _normalizer.is_sql(file_o.read(self.__sql_limit)):
             # calculate file checksum
             _md5sum = self.md5(file_o)
             # register MD5 sum as "Regular" for non-sql files

--- a/oc_delivery_apps/dlcontents/controllers.py
+++ b/oc_delivery_apps/dlcontents/controllers.py
@@ -243,6 +243,11 @@ class CheckSumsController(object):
 
         # otherwise store all. IS_DELETED will be False by Model.
         _ci_type = models.CiTypes.objects.filter(code=ci_type).last()
+
+        if not _ci_type:
+            # may be wrong type specified by caller, raise an exception
+            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+
         _loc = None
         _cs = None
 
@@ -610,6 +615,10 @@ class CheckSumsController(object):
 
         _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
 
+        if not _ci_type_r:
+            # may be wrong type specified by caller, raise an exception
+            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+
         file_o.seek(0, os.SEEK_SET)
         _cs_d = self.get_all_sql_checksums(file_o)
         _fl_m_r = None
@@ -821,6 +830,11 @@ class CheckSumsController(object):
             ci_type = self.ci_type_by_path(loc_path, loc_type)
 
         _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
+
+        if not _ci_type_r:
+            # may be wrong type specified by caller, raise an exception
+            raise ValueError("Incorrect CI_TYPE: [%s]" % ci_type)
+
         _fl_r = None
 
         try:

--- a/oc_delivery_apps/dlcontents/controllers.py
+++ b/oc_delivery_apps/dlcontents/controllers.py
@@ -13,6 +13,7 @@ import os
 import posixpath
 import shutil
 import logging
+from oc_cdtapi.NexusAPI import gav_to_path
 
 #BEG: DICTIONARIES
 # specific calculations should be placed here if needed
@@ -754,6 +755,32 @@ class CheckSumsController(object):
                 loc_type, loc_revision, inclusion_level, ci_type_sub, force_recalc, 0)
         return _fl_r
 
+    def _is_sql_extension(self, loc_path, loc_type):
+        """
+        Try to get extension from location path given and check against SQL
+        :param str loc_path: location path
+        :param str loc_type: location type code
+        """
+
+        if not loc_path:
+            logging.error("Empty location path given")
+            return False
+
+        # if location type is NXS (maven) then we have to convert it to path
+        # all other location types assumed to be POSIX-compatible
+        if isinstance(loc_type, str):
+            loc_type = loc_type.upper()
+
+        if loc_type == "NXS":
+            logging.debug("NXS location, converting GAV [%s] to POSIX path" % loc_path)
+            loc_path = gav_to_path(loc_path)
+            logging.debug("GAV converted to path: [%s]" % loc_path)
+
+        _ext = list(posixpath.splitext(loc_path)).pop().lower()
+        logging.debug("Extension is [%s]" % _ext)
+
+        return _ext in [".sql", ".plb"]
+
     def _register_file_obj(self, file_o, ci_type, loc_path, loc_type, loc_revision, inclusion_level, ci_type_sub, force_recalc, inclusion_level_calc):
         """
         Registers file or file-like object in the database. MD5 checksum and MIME-type of the file object will be calculated. 
@@ -783,7 +810,7 @@ class CheckSumsController(object):
         file_o.seek(0, 0)
         _inclusion_level_calc_src = inclusion_level_calc
 
-        if not _normalizer.is_sql(file_o.read(self.__sql_limit)):
+        if not self._is_sql_extension(loc_path, loc_type) and not _normalizer.is_sql(file_o.read(self.__sql_limit)):
             # calculate file checksum
             _md5sum = self.md5(file_o)
             # register MD5 sum as "Regular" for non-sql files

--- a/oc_delivery_apps/dlcontents/controllers.py
+++ b/oc_delivery_apps/dlcontents/controllers.py
@@ -239,22 +239,7 @@ class CheckSumsController(object):
         if not self._is_strict_cs_prov(cs_prov):
             return False
 
-        if not ci_type:
-            ci_type = self.ci_type_by_path(location, loc_type)
-
-        # otherwise store all. IS_DELETED will be False by Model.
-        _ci_type = models.CiTypes.objects.filter(code=ci_type).last()
-
-        if not _ci_type:
-            # may be wrong type specified by caller.
-            # Try to make it 'FILE' and raise an exception if not found
-            _ci_type = models.CiTypes.objects.filter(code='FILE').last()
-        
-        if not _ci_type:
-            raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
-        else:
-            logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)
-
+        _ci_type = self._ci_type_record(ci_type, location, loc_type)
         _loc = None
         _cs = None
 
@@ -369,12 +354,39 @@ class CheckSumsController(object):
 
         return self.add_inclusion(_fl_child, _fl_parent, path)
 
+    def _ci_type_record(self, ci_type, loc_path, loc_type):
+        """
+        Get ci-type record. Try to detect by path given and its location type if not exists.
+        Uses 'ci_type_by_path' first to detect a type if it is not given.
+        Returns a record from database for a type detected, and default one for 'FILE' if detection fails.
+        Raises an exception if record for CI_TYPE does not exist in database.
+        :param str ci_type: type to get record for
+        :param str loc_path: location path for autodetection
+        :param str loc_type: location type code for autodetection
+        :return oc_delivery_apps.checksums.CiTypes: a record for a type given, or autodetected one
+        """
+        if not ci_type:
+            # we are force to autodetect
+            ci_type = self.ci_type_by_path(loc_path, loc_type)
+            logging.debug("Location path: [%s]; Location type: [%s]; Autodetected CI_TYPE: [%s]" % (loc_path, loc_type, ci_type))
+        elif not models.CiTypes.objects.filter(code=ci_type).count():
+            _ci_type = self.ci_type_by_path(loc_path, loc_type)
+            logging.error("CI_TYPE not found: [%s], replaced to [%s]" % (ci_type, _ci_type))
+            ci_type = _ci_type
+
+        _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
+
+        if not _ci_type_r:
+            raise ValueError("CI_TYPE not found: [%s]" % ci_type)
+
+        return _ci_type_r
+
     def ci_type_by_path(self, path, loc_type):
         """
         Get ci-type code by path given and location type. Searches by regexp's in database and returns first CI_TYPE which's regexp path given has met to.
         :param str path: location path
         :param loc_type: location type code
-        :return str: ci-type code, or None if not found
+        :return str: ci-type code, or default 'FILE' if nothing found
         """
 
         if not loc_type:
@@ -617,20 +629,7 @@ class CheckSumsController(object):
         _file_pos = file_o.tell()
         _mime_type = self.mime(file_o)
 
-        if not ci_type:
-            ci_type = self.ci_type_by_path(loc_path, loc_type)
-
-        _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
-
-        if not _ci_type_r:
-            # may be wrong type specified by caller.
-            # Try to make it 'FILE' and raise an exception if not found
-            _ci_type_r = models.CiTypes.objects.filter(code='FILE').last()
-        
-        if not _ci_type_r:
-            raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
-        else:
-            logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)
+        _ci_type_r = self._ci_type_record(ci_type, loc_path, loc_type)
 
         file_o.seek(0, os.SEEK_SET)
         _cs_d = self.get_all_sql_checksums(file_o)
@@ -865,20 +864,7 @@ class CheckSumsController(object):
         if loc_path and not loc_type:
             raise ValueError("'loc_path' is specified but 'loc_type' missing")
 
-        if not ci_type:
-            ci_type = self.ci_type_by_path(loc_path, loc_type)
-
-        _ci_type_r = models.CiTypes.objects.filter(code=ci_type).last()
-
-        if not _ci_type_r:
-            # may be wrong type specified by caller.
-            # Try to make it 'FILE' and raise an exception if not found
-            _ci_type_r = models.CiTypes.objects.filter(code='FILE').last()
-        
-        if not _ci_type_r:
-            raise ValueError("Invalid CI_TYPE: [%s]" % ci_type)
-        else:
-            logging.error("Invalid CI_TYPE: [%s], replaced to [FILE]" % ci_type)
+        _ci_type_r = self._ci_type_record(ci_type, loc_path, loc_type)
 
         _fl_r = None
 

--- a/oc_delivery_apps/dlcontents/tests/test_controllers.py
+++ b/oc_delivery_apps/dlcontents/tests/test_controllers.py
@@ -375,7 +375,8 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
             _cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0)
 
         # now add the type - error sould disappear
-        models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="Y", is_deliverable=True).save()
+        _citype = models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="N", is_deliverable=False)
+        _citype.save()
         self.assertTrue(_cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0))
         self.assertEqual(models.Files.objects.count(), 1)
         self.assertEqual(models.Locations.objects.count(), 2)
@@ -389,8 +390,6 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
 
         # store file with another checksum but for existing location
         # file should be added and location overwritten
-        _citype = models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="N", is_deliverable=False)
-        _citype.save()
         _cs_t = "1"*32
         self.assertTrue(_cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0))
         self.assertEqual(models.Files.objects.count(), 2)

--- a/oc_delivery_apps/dlcontents/tests/test_controllers.py
+++ b/oc_delivery_apps/dlcontents/tests/test_controllers.py
@@ -375,7 +375,7 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
             _cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0)
 
         # now add the type - error sould disappear
-        _citype = models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="Y", is_deliverable=True)
+        models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="Y", is_deliverable=True).save()
         self.assertTrue(_cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0))
         self.assertEqual(models.Files.objects.count(), 1)
         self.assertEqual(models.Locations.objects.count(), 2)

--- a/oc_delivery_apps/dlcontents/tests/test_controllers.py
+++ b/oc_delivery_apps/dlcontents/tests/test_controllers.py
@@ -931,11 +931,15 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
 
         with self.assertRaises(ValueError):
             # ci_type is not detected - location missing
+            # "FILE" type is missing too
             _csc.register_file_md5(_cs2_t, None, "text/hypertrophed", None, "NXS")
 
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValueError):
             # ci_type is not detected - no regular expression
             _csc.register_file_md5(_cs2_t, None, "text/hypertrophed", "loc:path:3", "NXS")
+
+        # add 'FILE' type to get rid of ValueError in further asserts
+        models.CiTypes(code="FILE", name="A File", is_standard="N", is_deliverable=True).save()
 
         _fr_t2 = _csc.register_file_md5(_cs2_t, None, "text/hypertrophed", "loc:path:2:ext", "NXS")
         self.assertNotEqual(_fr_t2, _fr_t1)
@@ -1087,7 +1091,7 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
         self.assertEqual(_fl_r, models.Files.objects.last())
 
         # No ci_type_sub given
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValueError):
             _csc._register_includes(_arc_tgz_tmp, None, None, 1, False, 0)
 
         # No file record for an archive: try to find out file by file object

--- a/oc_delivery_apps/dlcontents/tests/test_controllers.py
+++ b/oc_delivery_apps/dlcontents/tests/test_controllers.py
@@ -1216,12 +1216,12 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
 
         with unittest.mock.patch("oc_delivery_apps.dlcontents.controllers.wrapper.PLSQLWrapper", return_value=MockWrapper()) as _x:
             _csc = CheckSumsController()
-            _csc.register_file_obj(_sql_f, "CODE_TYPE_1", "pl.sql.procedure:testproc:1.1.1", "NXS")
+            _csc.register_file_obj(_sql_f, "CODE_TYPE_1", "pl.sql.procedure:testproc:1.1.1:sql", "NXS")
             _x.assert_called()
 
         # check database checksums
         self.assertEqual(models.Locations.objects.count(), 1)
-        self.assertEqual(models.Locations.objects.last().path, "pl.sql.procedure:testproc:1.1.1")
+        self.assertEqual(models.Locations.objects.last().path, "pl.sql.procedure:testproc:1.1.1:sql")
         self.assertEqual(models.Files.objects.count(), 1)
         _fl_r = models.Files.objects.last()
         self.assertEqual(_fl_r.ci_type.code, "CODE_TYPE_1")
@@ -1230,7 +1230,56 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
         self.assertEqual(models.CsProv.objects.count(), 8)
         self.assertEqual(models.CheckSums.objects.filter(file=_fl_r).count(), 4)
 
-        # now add the same file once again and check  no duplicates appended
+        _sql_f.close()
+
+    def test_register_includes__sql_no_ext(self):
+        # prepare one PL/SQL file
+        _sql_c = b"create or replace procedure testproc(testarg in varchar2(100 char)) as t varchar2(100 char); begin t:=testarg.substr(1,0); end;"
+        _wrp_c = b"create or replace procedure testproc(testarg in varchar2(100 char)) wrapped abcdef abcdef abcdef"
+
+        # citype, loctype, cstype
+        _citype = models.CiTypes(code="CODE_TYPE_1", name="Name One", is_standard="N", is_deliverable=False)
+        _citype.save()
+        _loctype_n = models.LocTypes(code="NXS", name="Maven-compatible")
+        _loctype_n.save()
+        _cstype = models.CsTypes(code="MD5", name="MD5")
+        _cstype.save()
+
+        # make sure DB is empty
+        self.assertEqual(models.Files.objects.count(), 0)
+        self.assertEqual(models.Locations.objects.count(), 0)
+        self.assertEqual(models.CheckSums.objects.count(), 0)
+
+        # prepare file
+        _sql_f = tempfile.NamedTemporaryFile(suffix=".trt")
+        _sql_f.write(_sql_c)
+        _sql_f.flush()
+
+        # mock wrapper since we do not have original one
+        class MockWrapper(unittest.mock.MagicMock):
+            def wrap_buf(self, fl_in, write_to):
+                assert(write_to is not None)
+                write_to.write(_wrp_c)
+
+            def unwrap_buf(self, fl_in, write_to):
+                assert(write_to is not None)
+                write_to.write(_sql_c)
+
+        with unittest.mock.patch("oc_delivery_apps.checksums.controllers.wrapper.PLSQLWrapper", return_value=MockWrapper()) as _x:
+            _csc = CheckSumsController()
+            _csc.register_file_obj(_sql_f, "CODE_TYPE_1", "pl.sql.procedure:testproc:1.1.1", "NXS")
+            _x.assert_not_called()
+
+        # check database checksums
+        self.assertEqual(models.Locations.objects.count(), 1)
+        self.assertEqual(models.Locations.objects.last().path, "pl.sql.procedure:testproc:1.1.1")
+        self.assertEqual(models.Files.objects.count(), 1)
+        _fl_r = models.Files.objects.last()
+        self.assertEqual(_fl_r.ci_type.code, "CODE_TYPE_1")
+        # should be 1 checksum
+        self.assertEqual(models.CsProv.objects.count(), 1)
+        self.assertEqual(models.CheckSums.objects.filter(file=_fl_r).count(), 1)
+
         _sql_f.close()
 
     def test_get_file_by_file_obj(self):

--- a/oc_delivery_apps/dlcontents/tests/test_controllers.py
+++ b/oc_delivery_apps/dlcontents/tests/test_controllers.py
@@ -369,6 +369,13 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
         # NOTE: non-existent CI_TYPE is specified, this is NOT A BUG
         _loctype = models.LocTypes(code="SVN", name="SubVersion")
         _loctype.save()
+
+        # first it should raise an erorr - we do not have 'CODE_TYPE_2" here and "FILE" is missing also
+        with self.assertRaises(ValueError):
+            _cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0)
+
+        # now add the type - error sould disappear
+        _citype = models.CiTypes(code="CODE_TYPE_2", name="Name Two", is_standard="Y", is_deliverable=True)
         self.assertTrue(_cs.add_location_checksum(_cs_t, _pth, "SVN", "CODE_TYPE_2", revision=0))
         self.assertEqual(models.Files.objects.count(), 1)
         self.assertEqual(models.Locations.objects.count(), 2)

--- a/oc_delivery_apps/dlcontents/tests/test_controllers.py
+++ b/oc_delivery_apps/dlcontents/tests/test_controllers.py
@@ -1282,7 +1282,7 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
 
         with unittest.mock.patch("oc_delivery_apps.dlcontents.controllers.wrapper.PLSQLWrapper", return_value=MockWrapper()) as _x:
             _csc = CheckSumsController()
-            _csc.register_file_obj(_sql_f, "CODE_TYPE_1", "pl.sql.procedure:testproc:1.1.1", "NXS")
+            _csc.register_file_obj(_sql_f, "CODE_TYPE_1", "pl.sql.procedure:testproc:1.1.1:sql", "NXS")
             _x.assert_called()
 
         self.assertEqual(models.Files.objects.count(), 2)

--- a/oc_delivery_apps/dlcontents/tests/test_controllers.py
+++ b/oc_delivery_apps/dlcontents/tests/test_controllers.py
@@ -1828,3 +1828,63 @@ class CheckSumsControllersTester(django.test.TransactionTestCase):
 
         # this should not confuse us
         self.assertEqual(_csc.get_current_inclusion_depth_calc(_f1), 3)
+
+    def test_ci_type_record(self):
+        # no types in database - should raise ValueError
+        _csc = CheckSumsController()
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record('TYPE', 'path', 'loc')
+
+        # store one type and make sure ValueError is raised
+        _ci_type = models.CiTypes(code="T1", name="T1")
+        _ci_type.save()
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record('TYPE', 'path', 'loc')
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record('TYPE', 'path', 'loc')
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record('TYPE', None, 'loc')
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record('TYPE', 'path', None)
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record('TYPE', None, None)
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record(None, None, None)
+
+        # legal record
+        self.assertEqual(_ci_type.code, _csc._ci_type_record('T1', 'path', 'loc').code)
+        self.assertEqual(_ci_type.code, _csc._ci_type_record('T1', 'path', None).code)
+        self.assertEqual(_ci_type.code, _csc._ci_type_record('T1', None, None).code)
+        self.assertEqual(_ci_type.code, _csc._ci_type_record('T1', None, 'loc').code)
+
+        # give a 'FILE' type - assert it returned where possible
+        models.CiTypes(code='FILE', name='File').save()
+        self.assertEqual(_ci_type.code, _csc._ci_type_record('T1', 'path', 'loc').code)
+        self.assertEqual(_ci_type.code, _csc._ci_type_record('T1', 'path', None).code)
+        self.assertEqual(_ci_type.code, _csc._ci_type_record('T1', None, None).code)
+        self.assertEqual(_ci_type.code, _csc._ci_type_record('T1', None, 'loc').code)
+        self.assertEqual('FILE', _csc._ci_type_record('T_NONEXIST', 'path', 'loc').code)
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record('T_NONEXIST', 'path', None)
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record('T_NONEXIST', None, None)
+
+        with self.assertRaises(ValueError):
+            _csc._ci_type_record('T_NONEXIST', None, 'loc')
+
+        # add a regular expression
+        _loc = models.LocTypes(code="LOC", name="Location")
+        _loc.save()
+        models.CiRegExp(regexp='path', loc_type=_loc, ci_type=_ci_type).save()
+
+        self.assertEqual(_ci_type.code, _csc._ci_type_record(None, 'path', 'LOC').code) 
+        self.assertEqual(_ci_type.code, _csc._ci_type_record('T_NONEXIST', 'path', 'LOC').code) 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import glob
 import os
 
-__version = "11.2.10"
+__version = "11.3.0"
 
 spec = {
     "name": "oc-delivery-apps",


### PR DESCRIPTION
checksums, dlcontents - controllers:
- Archive registration improoved: no even try to detect `.sql` files if file extension is imporper
- Debug output appended and re-fatored somewhere
- Re-factored ci_type detection and falling to default `FILE` if not given or given wrong
- Unit-tests for new controllers methods