### PR TITLE
Extend code and name fields in checksums and dlcontents types models

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+Dockerfile
+docker-compose.yml
+*/.git/*
+.git*
+*/__pycache__/*
+*/*.py[oc]
+__pycache__
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*/__pycache__/*
 __pycache__
-*.py[oc]
+*/*.py[oc]
+*/build/*
 *.swp
+*egg-info*

--- a/oc_delivery_apps/checksums/migrations/0034_auto_20240530_0133.py
+++ b/oc_delivery_apps/checksums/migrations/0034_auto_20240530_0133.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('checksums', '0033_auto_20200117_0810'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='citypegroups',
+            name='code',
+            field=models.CharField(unique=True, max_length=127),
+        ),
+        migrations.AlterField(
+            model_name='citypegroups',
+            name='doc_artifactid',
+            field=models.CharField(max_length=1023, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='citypegroups',
+            name='name',
+            field=models.CharField(max_length=511),
+        ),
+        migrations.AlterField(
+            model_name='citypegroups',
+            name='rn_artifactid',
+            field=models.CharField(max_length=1023, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='citypes',
+            name='code',
+            field=models.CharField(unique=True, max_length=127),
+        ),
+        migrations.AlterField(
+            model_name='citypes',
+            name='doc_artifactid',
+            field=models.CharField(max_length=1023, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='citypes',
+            name='name',
+            field=models.CharField(unique=True, max_length=511),
+        ),
+        migrations.AlterField(
+            model_name='citypes',
+            name='rn_artifactid',
+            field=models.CharField(max_length=1023, null=True, blank=True),
+        )
+    ]

--- a/oc_delivery_apps/checksums/models.py
+++ b/oc_delivery_apps/checksums/models.py
@@ -10,16 +10,16 @@ import os
 class CiTypes(models.Model):
     # ID is not needed, added automatically as primary key
     # capital letters code
-    code = models.CharField(max_length=32, blank=False, null=False, unique=True)
+    code = models.CharField(max_length=127, blank=False, null=False, unique=True)
     # display name
-    name = models.CharField(max_length=64, blank=False, null=False, unique=True)
+    name = models.CharField(max_length=511, blank=False, null=False, unique=True)
     # is_standard, default - no
     is_standard = models.CharField(max_length=8, blank=False, null=False, default="N")
     # is deliverable to customers
     is_deliverable = models.BooleanField(default=False)
-    rn_artifactid = models.CharField(max_length=255, blank=True, null=True)
+    rn_artifactid = models.CharField(max_length=1023, blank=True, null=True)
     # artifactid needed for documentation appending
-    doc_artifactid = models.CharField(max_length=255, blank=True, null=True)
+    doc_artifactid = models.CharField(max_length=1023, blank=True, null=True)
 
     def get_rn_gav(self, version):
         """
@@ -61,13 +61,13 @@ class CiTypes(models.Model):
 class CiTypeGroups(models.Model):
     # ID is not needed, added by Django automatically as primary key
     # capital letters code
-    code = models.CharField(max_length=32, blank=False, null=False, unique=True)
+    code = models.CharField(max_length=127, blank=False, null=False, unique=True)
     # display name
-    name = models.CharField(max_length=64, blank=False, null=False)
+    name = models.CharField(max_length=511, blank=False, null=False)
     # Release notes artifactid
-    rn_artifactid = models.CharField(max_length=255, blank=True, null=True)
+    rn_artifactid = models.CharField(max_length=1023, blank=True, null=True)
     # artifactid needed for documentation appending
-    doc_artifactid = models.CharField(max_length=255, blank=True, null=True)
+    doc_artifactid = models.CharField(max_length=1023, blank=True, null=True)
 
     def get_rn_gav(self, version):
         """

--- a/oc_delivery_apps/dlcontents/migrations/0034_auto_20240530_0133.py
+++ b/oc_delivery_apps/dlcontents/migrations/0034_auto_20240530_0133.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dlcontents', '0033_auto_20180703_0008'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='citypegroups',
+            name='code',
+            field=models.CharField(unique=True, max_length=127),
+        ),
+        migrations.AlterField(
+            model_name='citypegroups',
+            name='name',
+            field=models.CharField(max_length=511),
+        ),
+        migrations.AlterField(
+            model_name='citypes',
+            name='code',
+            field=models.CharField(unique=True, max_length=127),
+        ),
+        migrations.AlterField(
+            model_name='citypes',
+            name='name',
+            field=models.CharField(unique=True, max_length=511),
+        )
+    ]

--- a/oc_delivery_apps/dlcontents/models.py
+++ b/oc_delivery_apps/dlcontents/models.py
@@ -10,9 +10,9 @@ import os
 class CiTypes(models.Model):
     # ID is not needed, added automatically as primary key
     # capital letters code
-    code = models.CharField(max_length=32, blank=False, null=False, unique=True)
+    code = models.CharField(max_length=127, blank=False, null=False, unique=True)
     # display name
-    name = models.CharField(max_length=64, blank=False, null=False, unique=True)
+    name = models.CharField(max_length=511, blank=False, null=False, unique=True)
     # is_standard, default - no
     is_standard = models.CharField(max_length=8, blank=False, null=False, default="N")
     # is deliverable to customers
@@ -28,9 +28,9 @@ class CiTypes(models.Model):
 class CiTypeGroups(models.Model):
     # ID is not needed, added by Django automatically as primary key
     # capital letters code
-    code = models.CharField(max_length=32, blank=False, null=False, unique=True)
+    code = models.CharField(max_length=127, blank=False, null=False, unique=True)
     # display name
-    name = models.CharField(max_length=64, blank=False, null=False)
+    name = models.CharField(max_length=511, blank=False, null=False)
     # Release notes artifactid
     rn_artifactid = models.CharField(max_length=255, blank=True, null=True)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import glob
 import os
 
-__version = "11.3.1"
+__version = "11.3.2"
 
 spec = {
     "name": "oc-delivery-apps",


### PR DESCRIPTION
- checksums, dlcontents: CiTypes, CiTypeGroups: `code` and `name` fields lenght increased; 
- migrations added; 
- `.gitignore` extended; 
- `.dockerignore` added